### PR TITLE
Lazy Annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,19 @@ class XOCLExtensionsAPI {
   ...
 }
 ```
+
+## @Lazy
+
+[`@Lazy`](https://github.com/kit-sdq/XAnnotations/blob/master/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/Lazy.xtend) can be declared on fields in order to initialise them lazily. That means that their initialiser code will not be executed before its first access:
+
+```xtend
+class Example {
+	@Lazy String field = expensiveComputation()
+	
+	def expensiveComputation() {
+		// will not be called before the first access of field
+	}
+}
+``` 
+
+To realise this behaviour, a getter `getField` will be generated through which the field will be accessed. `field` will be renamed to `_field` and should not be accessed directly. For more information, see [the annotation’s documentation](https://github.com/kit-sdq/XOCL/blob/master/bundles/edu.kit.ipd.sdq.xocl.extensions/src/edu/kit/ipd/sdq/xocl/extensions/XOCLExtensionsAPI.xtend).

--- a/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/Lazy.xtend
+++ b/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/Lazy.xtend
@@ -1,0 +1,96 @@
+package edu.kit.ipd.sdq.activextendannotations
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Target
+import org.eclipse.xtend.lib.macro.AbstractFieldProcessor
+import org.eclipse.xtend.lib.macro.Active
+import org.eclipse.xtend.lib.macro.TransformationContext
+import org.eclipse.xtend.lib.macro.declaration.MutableFieldDeclaration
+import org.eclipse.xtend.lib.macro.declaration.Visibility
+
+/**
+ * Lazily initializes a field. A field annotated with {@code @Lazy} will get a
+ * public getter that will, when called for the first time in the field’s
+ * lifetime, execute the field’s initializer. Subsequent calls will use the 
+ * computed value.
+ * 
+ * The initializer is guaranteed to be called at the first access and only
+ * once. Should it throw a runtime exception, that exception will be thrown at
+ * first access. In that case, the field will have its 
+ * {@link http://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html default value}. 
+ * 
+ * There are some restrictions for fields that are annotated as being 
+ * {@code @Lazy}:
+ * 
+ * <ul>
+ * <li>They must have an initializer (obviously)
+ * <li>They must be private
+ * </ul>
+ * 
+ * The field itself will be renamed to have an underscore ({@code field} -> 
+ * {@code _field}). It should <em>never</em> be reassigned by hand, as that 
+ * would likely break the contract of this annotation.
+ * 
+ * To know whether the annotated field was already initialized, 
+ * {@code _field_isInitialised} can be read. Once again, the field should
+ * <em>never</em> be assigned by hand as that would break this annotation’s
+ * contract.
+ * 
+ * This annotation was inspired by 
+ * {@link https://github.com/eclipse/xtext-xtend/blob/master/org.eclipse.xtend.examples/projects/xtend-annotation-examples/src/lazy/Lazy.xtend
+ * The Lazy annotation from Xtext’s active annotations example}
+ * 
+ * @author Joshua Gleitze
+ */
+@Target(ElementType.FIELD)
+@Active(LazyProcessor)
+annotation Lazy {
+}
+
+class LazyProcessor extends AbstractFieldProcessor {
+
+	override doTransform(MutableFieldDeclaration field, extension TransformationContext context) {
+		if (field.initializer === null)
+			field.addError("A lazy field must have an initializer.")
+
+		if (field.visibility != Visibility.PRIVATE)
+			field.addError("A lazy field must be private.")
+
+		val setter = field.declaringType.findDeclaredMethod('set' + field.simpleName.toFirstUpper, field.type)
+		if (setter !== null)
+			setter.addError("A lazy field cannot have a setter.")
+
+		val isInited = field.declaringType.addField('''_«field.simpleName»_isInitialised''') [
+			type = context.primitiveBoolean
+			initializer = '''false'''
+			visibility = Visibility.PRIVATE
+			static = field.static
+			primarySourceElement = field
+		]
+
+		val initializer = field.declaringType.addMethod('''_«field.simpleName»_initialise''') [
+			returnType = field.type
+			static = field.static
+			visibility = Visibility.PRIVATE
+			body = field.initializer
+		]
+
+		field.declaringType.addMethod('get' + field.simpleName.toFirstUpper) [
+			field.markAsRead
+			field.initializer
+			returnType = field.type
+			static = field.static
+			body = '''
+				if (!«isInited.simpleName») {
+					«isInited.simpleName» = true;
+					«field.simpleName» = «initializer.simpleName»();
+				}
+				return «field.simpleName»;
+			'''
+			primarySourceElement = field
+		]
+
+		field.simpleName = '''_«field.simpleName»'''
+		field.final = false
+	}
+}


### PR DESCRIPTION
The Xtext documentation [demonstrates how to write a `@Lazy` annotation](https://eclipse.org/xtend/documentation/204_activeannotations.html), but does not actually offer one. I guess that’s because its behaviour may be confusing in some corner cases.

I, however, find myself very often writing code that initialises a field lazily. Getting rid of initialisation checks is pretty cool from my point of view.

So I decided to write a `@Lazy` annotation that initialises a field on first access through a Getter. I thought that others might find it useful, too. 

As an example, this Xtend code:

```xtend
class Foo {
    @Lazy String bar = expensiveComputation

    def private static expensiveComputation() {
        ...
    }
}
```

will create (roughly) this Java code:

```java
public class Foo {
    @Lazy
    private String _bar;

    private static String expensiveComputation() {
        ...
    }

    private boolean __bar_isIntialised = false;

    private String __bar_initialise() {
        String _expensiveComputation = expensiveComputation();
        return _expensiveComputation;
    }

    public String getBar() {
        if (!__bar_isIntialised) {
            __bar_isIntialised = true;
            _bar = __bar_initialise();
        }
        return _bar;
    }
}
```

The generated Java code is more complicated than I’d like it to be, but there doesn’t seem to be a better way to implement this. Specifically, the `__field_initialise` method is necessary. Xtext will throw compiler errors if it is inlined into `getField`.

I created a new project, `edu.kit.ipd.sdq.commons.util.xtend` and an according feature to the repository.