### PR TITLE
Utility Class Annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,14 @@ class Example {
 ``` 
 
 To realise this behaviour, a getter `getField` will be generated through which the field will be accessed. `field` will be renamed to `_field` and should not be accessed directly. For more information, see [the annotation’s documentation](https://github.com/kit-sdq/XOCL/blob/master/bundles/edu.kit.ipd.sdq.xocl.extensions/src/edu/kit/ipd/sdq/xocl/extensions/XOCLExtensionsAPI.xtend).
+
+## @Utility
+
+[`@Utility`](https://github.com/kit-sdq/XAnnotations/blob/master/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/Utility.xtend) can be declared on classes to make them Utility classes. This means that they:
+
+ * are `final`
+ * only have one private, parameterless constructor that does nothing
+ * may only have `static` methods
+ * may have no fields but `static final` ones
+ 
+This annotation is meant to save some keystrokes, but to make Utility classes easier to detect.

--- a/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/Utility.xtend
+++ b/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/Utility.xtend
@@ -18,8 +18,8 @@ import org.eclipse.xtend.lib.macro.declaration.Visibility
  * and non-final static fields as these do not belong in a utility class and
  * were most likely added by accident.
  * 
- * Despite these changes to the generated source, this annotation is also meant
- * as a more declarative way of defining utility classes.
+ * Additionally to these changes to the generated source, this annotation is 
+ * also meant as a more declarative way of defining utility classes.
  */
 @Target(TYPE)
 @Active(UtilityProcessor)

--- a/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/Utility.xtend
+++ b/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/Utility.xtend
@@ -1,0 +1,71 @@
+package edu.kit.ipd.sdq.activextendannotations
+
+import java.lang.annotation.Target
+import org.eclipse.xtend.lib.macro.Active
+import org.eclipse.xtend.lib.macro.TransformationParticipant
+import java.util.List
+import org.eclipse.xtend.lib.macro.TransformationContext
+import org.eclipse.xtend.lib.macro.declaration.MutableTypeDeclaration
+import org.eclipse.xtend.lib.macro.ValidationParticipant
+import org.eclipse.xtend.lib.macro.ValidationContext
+import org.eclipse.xtend.lib.macro.declaration.MutableClassDeclaration
+import org.eclipse.xtend.lib.macro.declaration.Visibility
+
+/**
+ * Marks a class as a utility class. This makes the class `final`, adds a
+ * private, parameterless constructor and does not allow any other
+ * constructors. Additionally adds errors to instance methods, instance fields
+ * and non-final static fields as these do not belong in a utility class and
+ * were most likely added by accident.
+ * 
+ * Despite these changes to the generated source, this annotation is also meant
+ * as a more declarative way of defining utility classes.
+ */
+@Target(TYPE)
+@Active(UtilityProcessor)
+annotation Utility {
+}
+
+class UtilityProcessor implements TransformationParticipant<MutableTypeDeclaration>, ValidationParticipant<MutableTypeDeclaration> {
+
+	override doTransform(List<? extends MutableTypeDeclaration> annotatedTargetElements,
+		extension TransformationContext context) {
+		for (annotatedType : annotatedTargetElements) {
+			if (annotatedType instanceof MutableClassDeclaration) {
+				annotatedType.final = true
+				val privateParameterlessConstructors = annotatedType.declaredConstructors.filter [
+					visibility == Visibility.PRIVATE && parameters.length == 0
+				]
+				if (privateParameterlessConstructors.length == 0) {
+					annotatedType.addConstructor [
+						visibility = Visibility.PRIVATE
+						body = ''''''
+					]
+				}
+			}
+		}
+	}
+
+	override doValidate(List<? extends MutableTypeDeclaration> annotatedTargetElements,
+		extension ValidationContext context) {
+		for (annotatedType : annotatedTargetElements) {
+			if (annotatedType instanceof MutableClassDeclaration) {
+				annotatedType.declaredConstructors.filter[visibility != Visibility.PRIVATE || parameters.length > 0].
+					forEach [
+						addError("A Utility class may not have a constructor.")
+					]
+				annotatedType.declaredMethods.filter[!static].forEach [
+					addError("A Utility class may only have static methods.")
+				]
+				annotatedType.declaredFields.filter[!static].forEach [
+					addError("A Utility class must not have instance fields, as it is never constructed")
+				]
+				annotatedType.declaredFields.filter[static].filter[!final].forEach [
+					addError("A Utility class may only have final static fields, as it must not store state.")
+				]
+			} else {
+				annotatedType.addError("Only classes can be declared as Utility")
+			}
+		}
+	}
+}

--- a/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/Utility.xtend
+++ b/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/Utility.xtend
@@ -52,7 +52,8 @@ class UtilityProcessor implements TransformationParticipant<MutableTypeDeclarati
 			if (annotatedType instanceof MutableClassDeclaration) {
 				annotatedType.declaredConstructors.filter[visibility != Visibility.PRIVATE || parameters.length > 0].
 					forEach [
-						addError("A Utility class may not have a constructor.")
+						addError("A Utility class may only have a private, parameterless constructor " +
+							"(which is added automatically).")
 					]
 				annotatedType.declaredMethods.filter[!static].forEach [
 					addError("A Utility class may only have static methods.")


### PR DESCRIPTION
Marks utility classes. This saves some keystrokes and is also more declarative.