### PR TITLE
Include xtend-gen in Build

### DIFF
--- a/bundles/edu.kit.ipd.sdq.activextendannotations/build.properties
+++ b/bundles/edu.kit.ipd.sdq.activextendannotations/build.properties
@@ -1,4 +1,5 @@
-source.. = src/
+source.. = src/,\
+           xtend-gen/
 output.. = bin/
 bin.includes = META-INF/,\
                .


### PR DESCRIPTION
`xtend-gen` was not declared as source folder in `build.properties`, making the built jar useless.

I hope we’ll finally have a working build of this project after this PR.