### PR TITLE
@CloseResource

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,54 @@ This annotation is meant to save some keystrokes, but to make Utility classes ea
 [`@DelegateDeclared`](https://github.com/kit-sdq/XAnnotations/blob/master/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/DelegateDeclared.xtend) is a variant of the Xtend @Delegate active annotation that only delegates members that are declared in the interfaces which are implemented directly by the class that uses this annotation.
 
 For example, when delegating methods from an interface, only the methods declared in that interface are delegated. The methods that are declared in other interfaces which this interface extends are not delegated.
+
+## @CloseResource
+
+[`@CloseResource`](https://github.com/kit-sdq/XAnnotations/blob/master/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/CloseResource.xtend) is a replacement for Java’s try with resources, which is [not supported in Xtend](https://bugs.eclipse.org/bugs/show_bug.cgi?id=366020). Resource parameters annotated with it will be closed when the method exits – regardless if that happens by returning or by throwing an exception.
+
+So instead of writing (in Java):
+
+```java
+public static void writeToFileZipFileContents(String zipFileName,
+    String outputFileName) throws IOException {
+	Charset charset = StandardCharsets.US_ASCII;
+    Path outputFilePath = Paths.get(outputFileName);
+
+    try (
+        ZipFile zf = new ZipFile(zipFileName);
+        BufferedWriter writer = Files.newBufferedWriter(outputFilePath, charset)
+    ) {
+        for (Enumeration entries = zf.entries(); entries.hasMoreElements();) {
+            String newLine = System.getProperty("line.separator");
+            String zipEntryName =
+                 ((ZipEntry)entries.nextElement()).getName() + newLine;
+            writer.write(zipEntryName, 0, zipEntryName.length());
+        }
+    }
+}
+```
+
+one would write in Xtend:
+
+```Xtend
+def static void writeToFileZipFileContents(String zipFileName,
+    String outputFileName) throws IOException {
+    val charset = StandardCharsets.US_ASCII
+    val outputFilePath = Paths.get(outputFileName)
+
+    writeZipFile(new ZipFile(zipFileName),
+        Files.newBufferedWriter(outputFilePath, charset))
+}
+
+def private static void writeZipFile(@CloseResource ZipFile zf,
+    @CloseResource Writer writer) {
+    for (var entries = zf.entries(); entries.hasMoreElements();) {
+        String newLine = System.getProperty("line.separator")
+        String zipEntryName =
+             ((ZipEntry)entries.nextElement()).getName() + newLine
+        writer.write(zipEntryName, 0, zipEntryName.length())
+    }
+}
+
+```
+(the example was taken from the [Oracle Docs](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html))

--- a/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/CloseResource.xtend
+++ b/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/CloseResource.xtend
@@ -1,0 +1,188 @@
+package edu.kit.ipd.sdq.activextendannotations
+
+import org.eclipse.xtend.lib.macro.Active
+import java.lang.annotation.Target
+import org.eclipse.xtend.lib.macro.TransformationParticipant
+import org.eclipse.xtend.lib.macro.declaration.MutableParameterDeclaration
+import java.util.List
+import org.eclipse.xtend.lib.macro.TransformationContext
+import org.eclipse.xtend.lib.macro.declaration.MutableMethodDeclaration
+import org.eclipse.xtend.lib.macro.declaration.Visibility
+import org.eclipse.xtend.lib.macro.declaration.MutableExecutableDeclaration
+import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+import org.eclipse.xtend.lib.macro.declaration.MutableConstructorDeclaration
+import org.eclipse.xtend.lib.macro.declaration.ResolvedMethod
+import org.eclipse.xtend.lib.macro.ValidationParticipant
+import org.eclipse.xtend.lib.macro.ValidationContext
+import org.eclipse.xtend.lib.macro.declaration.TypeReference
+import java.util.Set
+import org.eclipse.xtend.lib.macro.services.TypeReferenceProvider
+
+/**
+ * Allows to declare method parameters as resources that will be closed when
+ * the method exits, no matter if it exits normally or by throwing an
+ * exception. Xtend does not support Java’s try with resources, so this
+ * annotation is a replacement until proper support is implemented. Instead of
+ * using a {@code try} block, the resources are declared in the method
+ * parameters using this extension. The method’s body will then wrapped in a
+ * try with resources block.
+ * 
+ * <p>Annotated parameters must implements {@link AutoCloseable}.
+ * 
+ * <p>Methods having parameters using this annotation must declare a return
+ * type due to a limitation in Xtend’s type inference system.
+ * 
+ * @see {@link https://bugs.eclipse.org/bugs/show_bug.cgi?id=366020}
+ * @author Joshua Gleitze
+ */
+@Active(CloseResourceProcessor)
+@Target(PARAMETER)
+annotation CloseResource {
+}
+
+class CloseResourceProcessor implements TransformationParticipant<MutableParameterDeclaration>, ValidationParticipant<MutableParameterDeclaration> {
+
+	override doTransform(List<? extends MutableParameterDeclaration> annotatedTargetElements,
+		extension TransformationContext context) {
+		val grouped = annotatedTargetElements.groupBy[declaringExecutable]
+		for (annotationEntry : grouped.entrySet) {
+			new CloseResourceExecutableProcessor(context).tranform(annotationEntry.key, annotationEntry.value)
+		}
+	}
+
+	@FinalFieldsConstructor
+	private static class CloseResourceExecutableProcessor {
+		var MutableExecutableDeclaration oldExecutable
+		var List<MutableParameterDeclaration> annotatedParameters
+		var MutableExecutableDeclaration newExecutable
+		var boolean doesReturn
+		val extension TransformationContext context
+		var extension TypeCopier typeCopier
+
+		
+		/**
+		 * Transforms the given {@code executable}.
+		 *
+		 * @param executable
+		 * 		The executable to transform
+		 * @param annotatedParameters
+		 * 		The subset of the {@code executable}’s parameters that is
+		 * 		annotated with {@code TryResource}.
+		 */
+		def tranform(MutableExecutableDeclaration executable,
+			List<MutableParameterDeclaration> annotatedParameters) {
+			this.annotatedParameters = annotatedParameters
+			val type = executable.declaringType
+
+			switch (executable) {
+				MutableMethodDeclaration: {
+					if (executable.returnType.isInferred) {
+						executable.addError("A method using @TryResource must declare its return type")
+						return
+					}
+					val newMethod = type.addMethod('''_«executable.simpleName»_with_safe_resources''')[]
+					withMethod(newMethod, executable)
+				}
+				MutableConstructorDeclaration: {
+					val newConstructor = type.addConstructor[]
+					withConstructor(newConstructor, executable)
+				}
+				default:
+					throw new AssertionError("Unknown subclass of MutableExecutableDeclration")
+			}
+
+			transform()
+		}
+
+		def withMethod(MutableMethodDeclaration newMethod, MutableMethodDeclaration oldMethod) {
+			typeCopier = new TypeCopier(context)
+			newMethod => [
+				copyTypeParametersFrom(oldMethod)
+				primarySourceElement = oldMethod
+				static = oldMethod.static
+				final = oldMethod.final
+				returnType = oldMethod.returnType.replaceTypeParameters
+			]
+			doesReturn = !oldMethod.returnType.isVoid
+			newExecutable = newMethod
+			oldExecutable = oldMethod
+		}
+
+		def withConstructor(MutableConstructorDeclaration constructor, MutableConstructorDeclaration oldConstructor) {
+			typeCopier = new TypeCopier(context)
+			constructor => [
+				primarySourceElement = oldConstructor
+			]
+			newExecutable = constructor
+			oldExecutable = oldConstructor
+			doesReturn = false
+		}
+
+		def transform() {
+			val extension info = new TypeInfo(context)
+			
+			newExecutable => [
+				visibility = Visibility.PRIVATE
+				body = oldExecutable.body
+				docComment = oldExecutable.docComment
+				varArgs = oldExecutable.isVarArgs
+				exceptions = oldExecutable.exceptions.map[replaceTypeParameters]
+			]
+			oldExecutable.parameters.forEach[newExecutable.addParameter(simpleName, type.replaceTypeParameters)]
+
+			// closing might throw exceptions -> declare them on the method
+			val closeExceptions = annotatedParameters
+				.map [type.withAllSuperTypes]
+				.map[map[declaredResolvedMethods.filter(ResolvedMethod).findFirst [simpleSignature == 'close()']].findFirst [it !== null]]
+				.filter [it !== null]
+				.map[resolvedExceptionTypes].flatten
+			oldExecutable.exceptions = (oldExecutable.exceptions + closeExceptions).toSet
+
+			oldExecutable.body = '''
+				try («FOR p : annotatedParameters SEPARATOR '; '»«p.type» r_«p.simpleName» = «p.simpleName»«ENDFOR») {
+					«IF doesReturn»return «ENDIF»«newExecutable.simpleName»(«FOR p : oldExecutable.parameters SEPARATOR ', '»«IF p.isAnnotated»r_«ENDIF»«p.simpleName»«ENDFOR»);
+				}			
+			'''
+			oldExecutable.docComment = ''
+		}
+
+		def isAnnotated(MutableParameterDeclaration parameter) {
+			return annotatedParameters.contains(parameter)
+		}
+	}
+
+	override doValidate(List<? extends MutableParameterDeclaration> annotatedTargetElements,
+		extension ValidationContext context) {
+		val extension info = new TypeInfo(context)
+		for (parameter : annotatedTargetElements) {
+			if (!parameter.type.hasSuperType(AutoCloseable)) {
+				parameter.addError("A resource for try-with-resources must implement AutoCloseable!")
+			}
+		}
+	}
+
+	@FinalFieldsConstructor
+	private static class TypeInfo {
+		val extension TypeReferenceProvider provider
+
+		/**
+		 * Checks whether the provided {@code typeReference} implements or
+		 * extends the provided {@code superType}.
+		 * 
+		 * @param typeReference
+		 * 		A type reference.
+		 * @param superType
+		 * 		The type to look for.
+		 * @return {@code true} iff {@code typeReference} or any of its super
+		 *  types is {@code superType}.
+		 */
+		def private hasSuperType(TypeReference typeReference, Class<?> superType) {
+			typeReference.withAllSuperTypes.contains(newTypeReference(superType))
+		}
+
+		def private Set<? extends TypeReference> withAllSuperTypes(TypeReference typeReference) {
+			(#[typeReference] + typeReference.declaredSuperTypes.map[withAllSuperTypes].flatten).toSet
+		}
+	}
+
+}

--- a/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/TypeCopier.xtend
+++ b/bundles/edu.kit.ipd.sdq.activextendannotations/src/edu/kit/ipd/sdq/activextendannotations/TypeCopier.xtend
@@ -1,0 +1,94 @@
+package edu.kit.ipd.sdq.activextendannotations
+
+import org.eclipse.xtend.lib.macro.declaration.MutableMethodDeclaration
+import org.eclipse.xtend.lib.macro.declaration.ResolvedMethod
+import org.eclipse.xtend.lib.macro.declaration.TypeReference
+import org.eclipse.xtend.lib.annotations.FinalFieldsConstructor
+import org.eclipse.xtend.lib.macro.TransformationContext
+import java.util.HashMap
+
+/**
+ * Helper to copy types from one method to another. Copying types is
+ * straightforward a long as no type parameters are involved. However,
+ * <em>if</em> type parameters are involved, they need to be copied and any
+ * reference to a type parameter needs to be replaced with its copy. This is
+ * handled by this class.
+ * 
+ * <p>A new instance of this class must be created for every method types are
+ * to be copied to.
+ */
+@FinalFieldsConstructor
+class TypeCopier {
+
+	val typeParameterMappings = new HashMap<TypeReference, TypeReference>
+	val extension TransformationContext context
+
+	/**
+	 * Copies all type parameters from the {@code source} method to the 
+	 * {@code target} method. The class can be used to replace type parameters
+	 * in type reference afterwards. 
+	 * 
+	 * @param target The method declaration to copy the type parameters to.
+	 * @param source The method declaration to copy the type parameters 
+	 * from.
+	 */
+	def copyTypeParametersFrom(MutableMethodDeclaration target, ResolvedMethod source) {
+		source.resolvedTypeParameters.forEach [ param |
+			val copy = target.addTypeParameter(param.declaration.simpleName, param.resolvedUpperBounds)
+			typeParameterMappings.put(param.declaration.newTypeReference, copy.newTypeReference)
+			copy.upperBounds = copy.upperBounds.map[replaceTypeParameters]
+		]
+	}
+
+	/**
+	 * Copies all type parameters from the {@code source} method to the 
+	 * {@code target} method. The class can be used to replace type parameters
+	 * in type reference afterwards. 
+	 * 
+	 * @param target The method declaration to copy the type parameters to.
+	 * @param source The method declaration to copy the type parameters 
+	 * from.
+	 */
+	def copyTypeParametersFrom(MutableMethodDeclaration target, MutableMethodDeclaration source) {
+		source.typeParameters.forEach [ param |
+			val copy = target.addTypeParameter(param.simpleName, param.upperBounds)
+			typeParameterMappings.put(param.newTypeReference, copy.newTypeReference)
+			copy.upperBounds = copy.upperBounds.map[replaceTypeParameters]
+		]
+	}
+
+	// the following two methods were copied from 
+	// org.eclipse.xtend.lib.annotations.DelegateProcessor.Util
+	/**
+	 * Replaces references to type parameters by their copies, which were
+	 * created by calling {@link copyTypeParametersFrom}. If
+	 * {@link copyTypeParametersFrom} was not called or the {@code source} it
+	 * was called with does not contain type parameters, the type reference
+	 * will be returned unchanged.
+	 * 
+	 * @param target The type reference to replace type parameters in.
+	 * @return An equal type reference that has all references to type
+	 * 		parameters replaced by their according copies.
+	 */
+	def TypeReference replaceTypeParameters(TypeReference target) {
+		typeParameterMappings.entrySet.fold(target)[result, mapping|result.replace(mapping.key, mapping.value)]
+	}
+
+	def private TypeReference replace(TypeReference target, TypeReference oldType, TypeReference newType) {
+		if (target == oldType)
+			return newType
+		if (!target.actualTypeArguments.isEmpty)
+			if (target.type !== null) {
+				return newTypeReference(target.type, target.actualTypeArguments.map[replace(oldType, newType)])
+			}
+		if (target.wildCard) {
+			if (target.upperBound != object)
+				return target.upperBound.replace(oldType, newType).newWildcardTypeReference
+			else if (!target.lowerBound.isAnyType)
+				return target.lowerBound.replace(oldType, newType).newWildcardTypeReferenceWithLowerBound
+		}
+		if (target.isArray)
+			return target.arrayComponentType.replace(oldType, newType).newArrayTypeReference
+		return target
+	}
+}


### PR DESCRIPTION
Adds an active annotation as a replacement for try with resources, which is [missing in Xtend](https://bugs.eclipse.org/bugs/show_bug.cgi?id=366020).

Also contains some refactoring for `@StaticDelegate`.